### PR TITLE
Polish the formulas

### DIFF
--- a/nvidia-driver/d12.sls
+++ b/nvidia-driver/d12.sls
@@ -58,7 +58,7 @@ nvidia-driver--assert-install:
     - period: 20
     - timeout: 600
     - args:
-      - modinfo -F name nvidia
+      - modinfo -F name nvidia-current
     - require:
       - pkg: nvidia-driver--install
 

--- a/nvidia-driver/d12.sls
+++ b/nvidia-driver/d12.sls
@@ -50,14 +50,5 @@ nvidia-driver--install:
       {# comment `nvidia-open-kernel-dkms` out to go full proprietary #}
     - requires:
       - cmd: nvidia-driver--install
-  loop.until_no_eval:
-    - name: cmd.run
-    - expected: 'nvidia'
-    - period: 20
-    - timeout: 600
-    - args:
-      - modinfo -F name nvidia-current
-    - require:
-      - pkg: nvidia-driver--install
 
 {% endif %}

--- a/nvidia-driver/d12.sls
+++ b/nvidia-driver/d12.sls
@@ -30,7 +30,6 @@ nvidia-driver--create-qube:
 {# Configure the repository #}
 nvidia-driver--enable-repo:
   pkgrepo.managed:
-    - humanname: deb-non-free
     - name: deb https://deb.debian.org/debian bookworm main contrib non-free non-free-firmware
     - file: /etc/apt/sources.list
 

--- a/nvidia-driver/d12.sls
+++ b/nvidia-driver/d12.sls
@@ -50,8 +50,6 @@ nvidia-driver--install:
       {# comment `nvidia-open-kernel-dkms` out to go full proprietary #}
     - requires:
       - cmd: nvidia-driver--install
-
-nvidia-driver--assert-install:
   loop.until_no_eval:
     - name: cmd.run
     - expected: 'nvidia'

--- a/nvidia-driver/f41.sls
+++ b/nvidia-driver/f41.sls
@@ -26,13 +26,8 @@ nvidia-driver--create-qube:
 {% elif grains['id'] == nvd_f41['standalone']['name'] %}
 
 nvidia-driver--enable-repo:
-  pkgrepo.managed:
-    - names: 
-      - rpmfusion-free
-      - rpmfusion-nonfree
-      - rpmfusion-free-updates
-      - rpmfusion-nonfree-updates
-    - enabled: true
+  cmd.run:
+    - name: dnf config-manager setopt rpmfusion-{free,nonfree}{,-updates}.enabled=1
 
 nvidia-driver--extend-tmp:
   cmd.run:
@@ -52,8 +47,6 @@ nvidia-driver--install:
     - require:
       - pkgrepo: nvidia-driver--enable-repo
       - cmd: nvidia-driver--extend-tmp
-
-nvidia-driver--assert-install:
   loop.until_no_eval:
     - name: cmd.run
     - expected: 'nvidia'
@@ -68,6 +61,6 @@ nvidia-driver--remove-conf:
   file.absent:
     - name: {{ nvd_f41['paths']['nvidia_conf'] }}
     - require:
-      - loop: nvidia-driver--assert-install
+      - loop: nvidia-driver--install
 
 {% endif %}

--- a/nvidia-driver/f41.sls
+++ b/nvidia-driver/f41.sls
@@ -39,8 +39,9 @@ nvidia-driver--extend-tmp:
     - name: mount -o remount,size=2G /tmp/
 
 nvidia-driver--remove-grubby-dummy:
-  cmd.run:
-    - name: dnf remove -y grubby-dummy
+  pkg.purged:
+    - pkgs:
+      - grubby-dummy
 
 nvidia-driver--install:
   pkg.installed:

--- a/nvidia-driver/f41.sls
+++ b/nvidia-driver/f41.sls
@@ -26,8 +26,13 @@ nvidia-driver--create-qube:
 {% elif grains['id'] == nvd_f41['standalone']['name'] %}
 
 nvidia-driver--enable-repo:
-  cmd.run:
-    - name: dnf config-manager setopt rpmfusion-{free,nonfree}{,-updates}.enabled=1
+  pkgrepo.managed:
+    - names: 
+      - rpmfusion-free
+      - rpmfusion-nonfree
+      - rpmfusion-free-updates
+      - rpmfusion-nonfree-updates
+    - enabled: true
 
 nvidia-driver--extend-tmp:
   cmd.run:
@@ -44,7 +49,7 @@ nvidia-driver--install:
       - xorg-x11-drv-nvidia-cuda
       {# - vulkan #}
     - require:
-      - cmd: nvidia-driver--enable-repo
+      - pkgrepo: nvidia-driver--enable-repo
       - cmd: nvidia-driver--extend-tmp
 
 nvidia-driver--assert-install:


### PR DESCRIPTION
Remove unnecessary states, use dedicated states instead of `cmd.run` where possible, join assertion and driver installation